### PR TITLE
[REFACTOR] Implement Hexagonal Architecture (Ports & Adapters)

### DIFF
--- a/src/main/java/com/teambind/articleserver/adapter/in/web/ArticleControllerV2.java
+++ b/src/main/java/com/teambind/articleserver/adapter/in/web/ArticleControllerV2.java
@@ -1,0 +1,110 @@
+package com.teambind.articleserver.adapter.in.web;
+
+import com.teambind.articleserver.application.port.in.CreateArticleUseCase;
+import com.teambind.articleserver.application.port.in.CreateArticleUseCase.ArticleInfo;
+import com.teambind.articleserver.application.port.in.CreateArticleUseCase.CreateArticleCommand;
+import com.teambind.articleserver.application.port.in.ReadArticleUseCase;
+import com.teambind.articleserver.application.port.in.ReadArticleUseCase.ArticleDetailInfo;
+import com.teambind.articleserver.application.port.in.ReadArticleUseCase.ArticlePageInfo;
+import com.teambind.articleserver.application.port.in.ReadArticleUseCase.SearchArticleQuery;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 게시글 REST Controller V2
+ *
+ * Hexagonal Architecture의 Inbound Adapter입니다.
+ * REST API를 통해 들어오는 요청을 Use Case로 전달합니다.
+ */
+@RestController
+@RequestMapping("/api/v2/articles")
+@RequiredArgsConstructor
+@Slf4j
+public class ArticleControllerV2 {
+
+    private final CreateArticleUseCase createArticleUseCase;
+    private final ReadArticleUseCase readArticleUseCase;
+
+    /**
+     * 게시글 생성
+     */
+    @PostMapping
+    public ResponseEntity<ArticleInfo> createArticle(@Valid @RequestBody CreateArticleRequest request) {
+        log.info("Creating article: title={}", request.title());
+
+        CreateArticleCommand command = new CreateArticleCommand(
+            request.title(),
+            request.content(),
+            request.writerId(),
+            request.boardId(),
+            request.keywordIds(),
+            request.eventStartDate(),
+            request.eventEndDate()
+        );
+
+        ArticleInfo articleInfo = createArticleUseCase.createArticle(command);
+        return ResponseEntity.ok(articleInfo);
+    }
+
+    /**
+     * 게시글 조회
+     */
+    @GetMapping("/{articleId}")
+    public ResponseEntity<ArticleDetailInfo> getArticle(@PathVariable String articleId) {
+        log.info("Getting article: id={}", articleId);
+
+        return readArticleUseCase.getArticle(articleId)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * 게시글 검색
+     */
+    @GetMapping("/search")
+    public ResponseEntity<ArticlePageInfo> searchArticles(
+            @RequestParam(required = false) Long boardId,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String content,
+            @RequestParam(required = false) String writerId,
+            @RequestParam(required = false) List<Long> keywordIds,
+            @RequestParam(defaultValue = "ACTIVE") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        SearchArticleQuery query = new SearchArticleQuery(
+            boardId, title, content, writerId, keywordIds, status, page, size
+        );
+
+        ArticlePageInfo pageInfo = readArticleUseCase.searchArticles(query);
+        return ResponseEntity.ok(pageInfo);
+    }
+
+    /**
+     * 게시글 생성 요청 DTO
+     */
+    public record CreateArticleRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다")
+        String content,
+
+        @NotBlank(message = "작성자 ID는 필수입니다")
+        String writerId,
+
+        @NotNull(message = "게시판 ID는 필수입니다")
+        Long boardId,
+
+        List<Long> keywordIds,
+        LocalDateTime eventStartDate,
+        LocalDateTime eventEndDate
+    ) {}
+}

--- a/src/main/java/com/teambind/articleserver/adapter/out/messaging/KafkaEventAdapter.java
+++ b/src/main/java/com/teambind/articleserver/adapter/out/messaging/KafkaEventAdapter.java
@@ -1,0 +1,50 @@
+package com.teambind.articleserver.adapter.out.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teambind.articleserver.application.port.out.PublishEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka 이벤트 어댑터
+ *
+ * Hexagonal Architecture의 Outbound Adapter입니다.
+ * 도메인 이벤트를 Kafka로 발행합니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaEventAdapter implements PublishEventPort {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String ARTICLE_CREATED_TOPIC = "article.created";
+    private static final String ARTICLE_DELETED_TOPIC = "article.deleted";
+
+    @Override
+    public void publishArticleCreatedEvent(ArticleCreatedEvent event) {
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send(ARTICLE_CREATED_TOPIC, event.articleId(), message);
+            log.info("Published article created event: articleId={}", event.articleId());
+        } catch (Exception e) {
+            log.error("Failed to publish article created event", e);
+            // 이벤트 발행 실패 시 처리 (재시도, DLQ 등)
+        }
+    }
+
+    @Override
+    public void publishArticleDeletedEvent(ArticleDeletedEvent event) {
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            kafkaTemplate.send(ARTICLE_DELETED_TOPIC, event.articleId(), message);
+            log.info("Published article deleted event: articleId={}", event.articleId());
+        } catch (Exception e) {
+            log.error("Failed to publish article deleted event", e);
+            // 이벤트 발행 실패 시 처리 (재시도, DLQ 등)
+        }
+    }
+}

--- a/src/main/java/com/teambind/articleserver/adapter/out/persistence/ArticlePersistenceAdapter.java
+++ b/src/main/java/com/teambind/articleserver/adapter/out/persistence/ArticlePersistenceAdapter.java
@@ -1,0 +1,61 @@
+package com.teambind.articleserver.adapter.out.persistence;
+
+import com.teambind.articleserver.application.port.out.LoadArticlePort;
+import com.teambind.articleserver.application.port.out.SaveArticlePort;
+import com.teambind.articleserver.entity.article.Article;
+import com.teambind.articleserver.entity.enums.Status;
+import com.teambind.articleserver.exceptions.CustomException;
+import com.teambind.articleserver.exceptions.ErrorCode;
+import com.teambind.articleserver.repository.ArticleRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 게시글 영속성 어댑터
+ *
+ * Hexagonal Architecture의 Outbound Adapter입니다.
+ * Port 인터페이스를 구현하여 실제 데이터베이스 작업을 수행합니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ArticlePersistenceAdapter implements LoadArticlePort, SaveArticlePort {
+
+    private final ArticleRepository articleRepository;
+
+    @Override
+    public Optional<Article> loadArticle(String articleId) {
+        log.debug("Loading article with id: {}", articleId);
+        return articleRepository.findById(articleId);
+    }
+
+    @Override
+    public Optional<Article> loadActiveArticle(String articleId) {
+        log.debug("Loading active article with id: {}", articleId);
+        return articleRepository.findById(articleId)
+            .filter(article -> article.getStatus() == Status.ACTIVE);
+    }
+
+    @Override
+    public boolean existsArticle(String articleId) {
+        return articleRepository.existsById(articleId);
+    }
+
+    @Override
+    public Article saveArticle(Article article) {
+        log.info("Saving article with id: {}", article.getId());
+        return articleRepository.save(article);
+    }
+
+    @Override
+    public void deleteArticle(String articleId) {
+        log.info("Soft deleting article with id: {}", articleId);
+        Article article = articleRepository.findById(articleId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        article.delete();
+        articleRepository.save(article);
+    }
+}

--- a/src/main/java/com/teambind/articleserver/application/port/in/CreateArticleUseCase.java
+++ b/src/main/java/com/teambind/articleserver/application/port/in/CreateArticleUseCase.java
@@ -1,0 +1,51 @@
+package com.teambind.articleserver.application.port.in;
+
+/**
+ * 게시글 생성 Use Case (Inbound Port)
+ *
+ * Hexagonal Architecture의 Inbound Port입니다.
+ * 외부에서 애플리케이션으로 들어오는 요청을 정의합니다.
+ */
+public interface CreateArticleUseCase {
+
+    /**
+     * 게시글 생성
+     *
+     * @param command 게시글 생성 명령
+     * @return 생성된 게시글 정보
+     */
+    ArticleInfo createArticle(CreateArticleCommand command);
+
+    /**
+     * 게시글 생성 명령 (Input DTO)
+     */
+    record CreateArticleCommand(
+        String title,
+        String content,
+        String writerId,
+        Long boardId,
+        java.util.List<Long> keywordIds,
+        java.time.LocalDateTime eventStartDate,
+        java.time.LocalDateTime eventEndDate
+    ) {
+        /**
+         * 이벤트 게시글 여부 확인
+         */
+        public boolean isEventArticle() {
+            return eventStartDate != null && eventEndDate != null;
+        }
+    }
+
+    /**
+     * 게시글 정보 (Output DTO)
+     */
+    record ArticleInfo(
+        String id,
+        String title,
+        String content,
+        String writerId,
+        String boardName,
+        String status,
+        java.time.LocalDateTime createdAt
+    ) {}
+}

--- a/src/main/java/com/teambind/articleserver/application/port/in/ReadArticleUseCase.java
+++ b/src/main/java/com/teambind/articleserver/application/port/in/ReadArticleUseCase.java
@@ -1,0 +1,68 @@
+package com.teambind.articleserver.application.port.in;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 게시글 조회 Use Case (Inbound Port)
+ */
+public interface ReadArticleUseCase {
+
+    /**
+     * ID로 게시글 조회
+     *
+     * @param articleId 게시글 ID
+     * @return 게시글 정보
+     */
+    Optional<ArticleDetailInfo> getArticle(String articleId);
+
+    /**
+     * 게시글 목록 조회
+     *
+     * @param query 조회 조건
+     * @return 게시글 목록
+     */
+    ArticlePageInfo searchArticles(SearchArticleQuery query);
+
+    /**
+     * 게시글 조회 조건
+     */
+    record SearchArticleQuery(
+        Long boardId,
+        String title,
+        String content,
+        String writerId,
+        List<Long> keywordIds,
+        String status,
+        int page,
+        int size
+    ) {}
+
+    /**
+     * 게시글 상세 정보
+     */
+    record ArticleDetailInfo(
+        String id,
+        String title,
+        String content,
+        String writerId,
+        String boardName,
+        List<String> keywords,
+        List<String> imageUrls,
+        String status,
+        Long viewCount,
+        java.time.LocalDateTime createdAt,
+        java.time.LocalDateTime updatedAt
+    ) {}
+
+    /**
+     * 페이징된 게시글 목록
+     */
+    record ArticlePageInfo(
+        List<ArticleDetailInfo> articles,
+        int currentPage,
+        int totalPages,
+        long totalElements,
+        boolean hasNext
+    ) {}
+}

--- a/src/main/java/com/teambind/articleserver/application/port/out/LoadArticlePort.java
+++ b/src/main/java/com/teambind/articleserver/application/port/out/LoadArticlePort.java
@@ -1,0 +1,37 @@
+package com.teambind.articleserver.application.port.out;
+
+import com.teambind.articleserver.entity.article.Article;
+import java.util.Optional;
+
+/**
+ * 게시글 조회 Port (Outbound Port)
+ *
+ * Hexagonal Architecture의 Outbound Port입니다.
+ * 애플리케이션에서 외부 시스템(DB 등)으로 나가는 요청을 정의합니다.
+ */
+public interface LoadArticlePort {
+
+    /**
+     * ID로 게시글 조회
+     *
+     * @param articleId 게시글 ID
+     * @return 게시글 엔티티
+     */
+    Optional<Article> loadArticle(String articleId);
+
+    /**
+     * 활성화된 게시글 조회
+     *
+     * @param articleId 게시글 ID
+     * @return 활성 게시글 엔티티
+     */
+    Optional<Article> loadActiveArticle(String articleId);
+
+    /**
+     * 게시글 존재 여부 확인
+     *
+     * @param articleId 게시글 ID
+     * @return 존재 여부
+     */
+    boolean existsArticle(String articleId);
+}

--- a/src/main/java/com/teambind/articleserver/application/port/out/PublishEventPort.java
+++ b/src/main/java/com/teambind/articleserver/application/port/out/PublishEventPort.java
@@ -1,0 +1,45 @@
+package com.teambind.articleserver.application.port.out;
+
+/**
+ * 이벤트 발행 Port (Outbound Port)
+ *
+ * 도메인 이벤트를 외부 시스템으로 발행합니다.
+ */
+public interface PublishEventPort {
+
+    /**
+     * 게시글 생성 이벤트 발행
+     *
+     * @param event 게시글 생성 이벤트
+     */
+    void publishArticleCreatedEvent(ArticleCreatedEvent event);
+
+    /**
+     * 게시글 삭제 이벤트 발행
+     *
+     * @param event 게시글 삭제 이벤트
+     */
+    void publishArticleDeletedEvent(ArticleDeletedEvent event);
+
+    /**
+     * 게시글 생성 이벤트
+     */
+    record ArticleCreatedEvent(
+        String articleId,
+        String title,
+        String writerId,
+        Long boardId,
+        java.time.LocalDateTime occurredAt
+    ) {}
+
+    /**
+     * 게시글 삭제 이벤트
+     */
+    record ArticleDeletedEvent(
+        String articleId,
+        String title,
+        String writerId,
+        String reason,
+        java.time.LocalDateTime occurredAt
+    ) {}
+}

--- a/src/main/java/com/teambind/articleserver/application/port/out/SaveArticlePort.java
+++ b/src/main/java/com/teambind/articleserver/application/port/out/SaveArticlePort.java
@@ -1,0 +1,24 @@
+package com.teambind.articleserver.application.port.out;
+
+import com.teambind.articleserver.entity.article.Article;
+
+/**
+ * 게시글 저장 Port (Outbound Port)
+ */
+public interface SaveArticlePort {
+
+    /**
+     * 게시글 저장
+     *
+     * @param article 저장할 게시글
+     * @return 저장된 게시글
+     */
+    Article saveArticle(Article article);
+
+    /**
+     * 게시글 삭제 (Soft Delete)
+     *
+     * @param articleId 삭제할 게시글 ID
+     */
+    void deleteArticle(String articleId);
+}

--- a/src/main/java/com/teambind/articleserver/application/service/CreateArticleService.java
+++ b/src/main/java/com/teambind/articleserver/application/service/CreateArticleService.java
@@ -1,0 +1,147 @@
+package com.teambind.articleserver.application.service;
+
+import com.teambind.articleserver.application.port.in.CreateArticleUseCase;
+import com.teambind.articleserver.application.port.out.LoadArticlePort;
+import com.teambind.articleserver.application.port.out.PublishEventPort;
+import com.teambind.articleserver.application.port.out.SaveArticlePort;
+import com.teambind.articleserver.entity.article.Article;
+import com.teambind.articleserver.entity.articleType.EventArticle;
+import com.teambind.articleserver.entity.articleType.NoticeArticle;
+import com.teambind.articleserver.entity.articleType.RegularArticle;
+import com.teambind.articleserver.entity.board.Board;
+import com.teambind.articleserver.entity.enums.Status;
+import com.teambind.articleserver.entity.keyword.Keyword;
+import com.teambind.articleserver.exceptions.CustomException;
+import com.teambind.articleserver.exceptions.ErrorCode;
+import com.teambind.articleserver.repository.BoardRepository;
+import com.teambind.articleserver.repository.KeywordRepository;
+import com.teambind.articleserver.utils.generator.primay_key.PrimaryKetGenerator;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 게시글 생성 애플리케이션 서비스
+ *
+ * Hexagonal Architecture의 Application Service입니다.
+ * Use Case를 구현하고 Port들을 조합하여 비즈니스 로직을 수행합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class CreateArticleService implements CreateArticleUseCase {
+
+    private final SaveArticlePort saveArticlePort;
+    private final PublishEventPort publishEventPort;
+    private final BoardRepository boardRepository;
+    private final KeywordRepository keywordRepository;
+    private final PrimaryKetGenerator primaryKetGenerator;
+
+    @Override
+    public ArticleInfo createArticle(CreateArticleCommand command) {
+        log.info("Creating article with title: {}", command.title());
+
+        // Board 조회
+        Board board = boardRepository.findById(command.boardId())
+            .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+        // Keywords 조회
+        List<Keyword> keywords = fetchKeywords(command.keywordIds());
+
+        // Article 생성 (타입에 따라 분기)
+        Article article = createArticleByType(command, board, keywords);
+
+        // 저장
+        Article savedArticle = saveArticlePort.saveArticle(article);
+
+        // 이벤트 발행
+        publishArticleCreatedEvent(savedArticle);
+
+        // DTO 변환 및 반환
+        return toArticleInfo(savedArticle);
+    }
+
+    private Article createArticleByType(CreateArticleCommand command, Board board, List<Keyword> keywords) {
+        String articleId = primaryKetGenerator.generateKey();
+
+        Article article;
+        if (command.isEventArticle() || "이벤트".equals(board.getName())) {
+            // Event Article
+            article = EventArticle.builder()
+                .id(articleId)
+                .title(command.title())
+                .content(command.content())
+                .writerId(command.writerId())
+                .board(board)
+                .keywordMappings(new ArrayList<>())
+                .status(Status.ACTIVE)
+                .eventStartDate(command.eventStartDate())
+                .eventEndDate(command.eventEndDate())
+                .build();
+        } else if ("공지사항".equals(board.getName())) {
+            // Notice Article
+            article = NoticeArticle.builder()
+                .id(articleId)
+                .title(command.title())
+                .content(command.content())
+                .writerId(command.writerId())
+                .board(board)
+                .keywordMappings(new ArrayList<>())
+                .status(Status.ACTIVE)
+                .build();
+        } else {
+            // Regular Article
+            article = RegularArticle.builder()
+                .id(articleId)
+                .title(command.title())
+                .content(command.content())
+                .writerId(command.writerId())
+                .board(board)
+                .keywordMappings(new ArrayList<>())
+                .status(Status.ACTIVE)
+                .build();
+        }
+
+        // Keywords 추가
+        if (keywords != null && !keywords.isEmpty()) {
+            article.addKeywords(keywords);
+        }
+
+        return article;
+    }
+
+    private List<Keyword> fetchKeywords(List<Long> keywordIds) {
+        if (keywordIds == null || keywordIds.isEmpty()) {
+            return null;
+        }
+        return keywordRepository.findAllById(keywordIds);
+    }
+
+    private void publishArticleCreatedEvent(Article article) {
+        PublishEventPort.ArticleCreatedEvent event = new PublishEventPort.ArticleCreatedEvent(
+            article.getId(),
+            article.getTitle(),
+            article.getWriterId(),
+            article.getBoard() != null ? article.getBoard().getId() : null,
+            LocalDateTime.now()
+        );
+        publishEventPort.publishArticleCreatedEvent(event);
+    }
+
+    private ArticleInfo toArticleInfo(Article article) {
+        return new ArticleInfo(
+            article.getId(),
+            article.getTitle(),
+            article.getContent(),
+            article.getWriterId(),
+            article.getBoard() != null ? article.getBoard().getName() : null,
+            article.getStatus().name(),
+            article.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Apply Hexagonal Architecture pattern to achieve dependency inversion
- Separate domain logic from infrastructure concerns
- Enable testability and flexibility through ports and adapters

## Architecture Overview
```
┌─────────────────────────────────────────────┐
│           Driving Side (Input)              │
│  ┌─────────────────────────────────────┐   │
│  │    REST API (ArticleControllerV2)   │   │
│  └────────────┬────────────────────────┘   │
│               │                             │
│  ┌────────────▼────────────────────────┐   │
│  │   Inbound Ports (Use Cases)         │   │
│  │  - CreateArticleUseCase             │   │
│  │  - ReadArticleUseCase               │   │
│  └────────────┬────────────────────────┘   │
│               │                             │
│  ┌────────────▼────────────────────────┐   │
│  │   Application Services               │   │
│  │  - CreateArticleService             │   │
│  └────────────┬────────────────────────┘   │
│               │                             │
│  ┌────────────▼────────────────────────┐   │
│  │   Outbound Ports                    │   │
│  │  - LoadArticlePort                  │   │
│  │  - SaveArticlePort                  │   │
│  │  - PublishEventPort                 │   │
│  └────────────┬────────────────────────┘   │
│               │                             │
│           Driven Side (Output)              │
│  ┌────────────▼────────────────────────┐   │
│  │   Adapters                          │   │
│  │  - ArticlePersistenceAdapter        │   │
│  │  - KafkaEventAdapter                │   │
│  └─────────────────────────────────────┘   │
└─────────────────────────────────────────────┘
```

## Changes

### Ports (Application Layer)
- **Inbound Ports**
  - `CreateArticleUseCase`: Article creation contract
  - `ReadArticleUseCase`: Article query contract
  
- **Outbound Ports**
  - `LoadArticlePort`: Data retrieval contract
  - `SaveArticlePort`: Data persistence contract
  - `PublishEventPort`: Event publishing contract

### Adapters (Infrastructure Layer)
- **Inbound Adapters**
  - `ArticleControllerV2`: REST API adapter
  
- **Outbound Adapters**
  - `ArticlePersistenceAdapter`: JPA/Database adapter
  - `KafkaEventAdapter`: Message broker adapter

### Application Services
- `CreateArticleService`: Orchestrates use cases using ports

## Benefits
- **Testability**: Domain logic can be tested without infrastructure
- **Flexibility**: Easy to swap implementations (e.g., change database, message broker)
- **Dependency Inversion**: Domain doesn't depend on infrastructure
- **Clear Boundaries**: Explicit contracts between layers
- **Technology Agnostic**: Core business logic is isolated from frameworks

## Migration Strategy
- Existing code remains functional (backward compatible)
- New V2 endpoints demonstrate the pattern
- Gradual migration path available
- No breaking changes to existing APIs

## Test Plan
- [ ] Unit tests for application services with mock ports
- [ ] Integration tests for adapters
- [ ] Contract tests for ports
- [ ] End-to-end tests through V2 API
- [ ] Performance comparison with existing implementation